### PR TITLE
Check if $XDG_CONFIG_HOME is set.

### DIFF
--- a/maza
+++ b/maza
@@ -7,7 +7,7 @@ set -e
 NAME_OSX="Darwin"
 THIS_OS=$(uname -mrs)
 PROGNAME=$(basename $0)
-CONFIG=($HOME/.maza/)
+[[ -z "${XDG_CONFIG_HOME}" ]] && CONFIG=$HOME/.maza/ || CONFIG=$XDG_CONFIG_HOME/maza
 HOST_FILE=(/etc/hosts)
 COLOR_RED=`tput setaf 1`
 COLOR_GREEN=`tput setaf 2`


### PR DESCRIPTION
Check to see if the end user has chosen to comply with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)