### PR TITLE
Update Maza Script to Appease Shellcheck Linter

### DIFF
--- a/maza
+++ b/maza
@@ -7,12 +7,12 @@ set -e
 URL_DNS_LIST="https://pgl.yoyo.org/adservers/serverlist.php?showintro=0&mimetype=plaintext"
 NAME_OSX="Darwin"
 THIS_OS=$(uname -mrs)
-PROGNAME=$(basename $0)
+PROGNAME=$(basename "$0")
 [[ -z "${XDG_CONFIG_HOME}" ]] && CONFIG=$HOME/.maza/ || CONFIG=$XDG_CONFIG_HOME/maza
-HOST_FILE=(/etc/hosts)
-COLOR_RED=`tput setaf 1`
-COLOR_GREEN=`tput setaf 2`
-COLOR_RESET=`tput sgr0`
+HOST_FILE=/etc/hosts
+COLOR_RED=$(tput setaf 1)
+COLOR_GREEN=$(tput setaf 2)
+COLOR_RESET=$(tput sgr0)
 LIST="list"
 LIST_DNSMASQ="dnsmasq.conf"
 START_TAG="## MAZA - List ad blocking"
@@ -72,9 +72,9 @@ status() {
 
 update() {
     # Make conf folder
-    rm -f $CONFIG$LIST
-    rm -f $CONFIG$LIST_DNSMASQ
-    mkdir -p $CONFIG
+    rm -f "$CONFIG$LIST"
+    rm -f "$CONFIG$LIST_DNSMASQ"
+    mkdir -p "$CONFIG"
     # Download DNS list
     curl -L -s "$URL_DNS_LIST" -o "$CONFIG$LIST"
     # Clear list
@@ -90,13 +90,13 @@ update() {
     custom-sed -i.bak "1i\\$PROJECT" "$CONFIG$LIST"
     custom-sed -i.bak "1i\\$START_TAG" "$CONFIG$LIST"
     ## Add end tag DNS list in first line
-    echo $END_TAG >> "$CONFIG/$LIST"
+    echo "$END_TAG" >> "$CONFIG/$LIST"
     ## Add start tag DNS dnsmasq in first line
     custom-sed -i.bak "1i\\$AUTHOR" "$CONFIG$LIST_DNSMASQ"
     custom-sed -i.bak "1i\\$PROJECT" "$CONFIG$LIST_DNSMASQ"
     custom-sed -i.bak "1i\\$START_TAG" "$CONFIG$LIST_DNSMASQ"
     ## Add end tag DNS DNSMASQ in first line
-    echo $END_TAG >> "$CONFIG$LIST_DNSMASQ"
+    echo "$END_TAG" >> "$CONFIG$LIST_DNSMASQ"
     # Remove temp file
     rm "$CONFIG$LIST.bak"
     rm "$CONFIG$LIST_DNSMASQ.bak"
@@ -117,7 +117,7 @@ stop() {
     custom-sed -i "/$START_TAG/,/$END_TAG/d" "$HOST_FILE"
 
     # Remove DNSMASQ
-    cat /dev/null > $CONFIG$LIST_DNSMASQ
+    cat /dev/null > "$CONFIG$LIST_DNSMASQ"
 
     # Notify user
     echo "${COLOR_GREEN}DISABLED!${COLOR_RESET}"


### PR DESCRIPTION
The [Shellcheck](https://www.shellcheck.net) linter raised a few issues with the previous version of this script; see Issue #6 for short discussion. This commit simply implements the changes recommended by Shellcheck.